### PR TITLE
adds eslint into the webpack hot process

### DIFF
--- a/client/config/settings.js
+++ b/client/config/settings.js
@@ -111,6 +111,7 @@ function appSettings(name, port, options) {
     templateData: {}, // Object that will be passed to every page as it is rendered
     templateMap: {}, // Used to specify specific templates on a per file basis
     stage: options.stage,
+    shouldLint: options.shouldLint,
     buildSuffix,
     port,
     production: isProduction(options.stage),

--- a/client/config/webpack.config.js
+++ b/client/config/webpack.config.js
@@ -40,6 +40,9 @@ module.exports = function webpackConfig(app) {
   const babelLoader = `babel-loader?${babelPlugins}&${presets}`;
 
   const jsLoaders = [babelLoader];
+  if (app.shouldLint) {
+    jsLoaders.push('atomic-lint-loader');
+  }
 
   const cssLoaders = ['css-loader?importLoaders=1', 'postcss-loader'];
 

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "assets-webpack-plugin": "^3.5.1",
+    "atomic-lint-loader": "^1.0.1",
     "autoprefixer": "^6.7.7",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.2",

--- a/client/webpack.hot.js
+++ b/client/webpack.hot.js
@@ -15,6 +15,7 @@ const serverApp = express();
 const localIp = '0.0.0.0';
 const appName = _.trim(argv._[0]);
 const hotPack = argv.hotPack;
+const shouldLint = argv.lint;
 
 function setupMiddleware(app) {
 
@@ -52,7 +53,7 @@ function launch(app) {
   runServer(app.port, app.outputPath);
 }
 
-const options = { hotPack, stage: 'hot', onlyPack: false, port: settings.hotPort };
+const options = { hotPack, shouldLint, stage: 'hot', onlyPack: false, port: settings.hotPort };
 if (appName) {
   const result = clientApps.buildApp(appName, options);
   launch(result.app);

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -326,6 +326,12 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
 
+atomic-lint-loader@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/atomic-lint-loader/-/atomic-lint-loader-1.0.1.tgz#da6877bd7e8a7e8efd86fd4808c6ee14935d3078"
+  dependencies:
+    lodash "^4.17.4"
+
 autoprefixer@^6.3.1, autoprefixer@^6.7.7:
   version "6.7.7"
   resolved "https://registry.yarnpkg.com/autoprefixer/-/autoprefixer-6.7.7.tgz#1dbd1c835658e35ce3f9984099db00585c782014"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "coverage": "cat ./coverage/**/coverage.info | ./client/node_modules/coveralls/bin/coveralls.js",
     "hot": "cd ./client && node webpack.hot.js",
     "hot_pack": "cd ./client && node webpack.hot.js --hotPack",
+    "hot_lint": "cd ./client && node webpack.hot.js --hotPack --lint",
     "live": "cd ./client && node server.js",
     "build_dev": "cd ./client && node ./build.js",
     "build_dev_pack": "cd ./client && node ./build.js --onlyPack",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "postinstall": "cd ./client && yarn",
     "test": "cd ./client && ./node_modules/karma/bin/karma start",
     "coverage": "cat ./coverage/**/coverage.info | ./client/node_modules/coveralls/bin/coveralls.js",
-    "hot": "cd ./client && node webpack.hot.js",
+    "hot": "cd ./client && node webpack.hot.js --lint",
     "hot_pack": "cd ./client && node webpack.hot.js --hotPack",
     "hot_lint": "cd ./client && node webpack.hot.js --hotPack --lint",
     "live": "cd ./client && node server.js",


### PR DESCRIPTION
this does a couple of things:
* During the wepback build process it lints all of the files that have been changed. When webpack first initializes it uses your git commands to determine any files that have changes while webpack wasn't running. During hot reload it just lints the files that get updated during the reload.

* It fails the build if a linter rule with a severity of 2 fails.

here is the loader code https://github.com/dittonjs/atomic-lint-loader. We should probably move this to atomic jolt sometime.