### PR TITLE
Adds node debugger support to jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "postinstall": "cd ./client && yarn",
     "test": "cd ./client && for dir in apps/*; do cd \"$dir\" || continue; yarn test; cd ..; cd ..; done",
-    "test_debug": "cd ./client && node debug ./node_modules/jest/bin/jest --runInBand --config=config/jest_config.json",
+    "test_debug": "cd ./client && for dir in apps/*; do cd \"$dir\" || continue; node debug ./node_modules/jest/bin/jest --runInBand --config=config/jest_config.json; cd ..; cd ..; done",
     "watch": "cd ./client && for dir in apps/*; do cd \"$dir\" || continue; yarn watch; cd ..; cd ..; done",
     "hot": "cd ./client && node webpack.hot.js",
     "hot_pack": "cd ./client && node webpack.hot.js --hotPack",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "postinstall": "cd ./client && yarn",
     "test": "cd ./client && for dir in apps/*; do cd \"$dir\" || continue; yarn test; cd ..; cd ..; done",
+    "test_debug": "cd ./client && node debug ./node_modules/jest/bin/jest --runInBand --config=config/jest_config.json",
     "watch": "cd ./client && for dir in apps/*; do cd \"$dir\" || continue; yarn watch; cd ..; cd ..; done",
     "hot": "cd ./client && node webpack.hot.js",
     "hot_pack": "cd ./client && node webpack.hot.js --hotPack",


### PR DESCRIPTION
Supports the use of the built in node debugger for jest tests. You can use it by adding a `debugger` statement to a spec, and using `yarn test_debug`